### PR TITLE
fixed invalid category from TRIVIA to KNOWLEDGE_AND_TRIVIA

### DIFF
--- a/skill.json
+++ b/skill.json
@@ -15,7 +15,7 @@
       },
       "isAvailableWorldwide": true,
       "testingInstructions": "Sample Testing Instructions.",
-      "category": "TRIVIA",
+      "category": "KNOWLEDGE_AND_TRIVIA",
       "distributionCountries": []
     },
     "apis": {


### PR DESCRIPTION
The project wouldn't deploy with the ASK DEPLOY command until I changed the category.  Apparently Amazon reorganized the categories.  (Fix Issue #35 that I reported.) 