### PR TITLE
npm modules must be installed in lambda/custom

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,10 +62,10 @@ Alexa, start reindeer trivia
 	$ ask init
 	```
 
-3. Install npm dependencies by navigating into the `/lambda` directory and running the npm command: `npm install`
+3. Install npm dependencies by navigating into the `/lambda/custom` directory and running the npm command: `npm install`
 
 	```bash
-	$ cd lambda
+	$ cd lambda/custom
 	$ npm install
 	```
 


### PR DESCRIPTION
I am getting an error while trying to install them in lambda folder. They must be installed in lambda/custom like other sample skills