### PR TITLE
Use speak off of responseBuilder

### DIFF
--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -355,13 +355,13 @@ const UnhandledIntent = {
         .getResponse();
     } else if (sessionAttributes.questions) {
       const speechOutput = requestAttributes.t('TRIVIA_UNHANDLED', ANSWER_COUNT.toString());
-      return handlerInput.attributesManager
+      return handlerInput.responseBuilder
         .speak(speechOutput)
         .reprompt(speechOutput)
         .getResponse();
     }
     const speechOutput = requestAttributes.t('HELP_UNHANDLED');
-    return handlerInput.attributesManager.speak(speechOutput).reprompt(speechOutput).getResponse();
+    return handlerInput.responseBuilder.speak(speechOutput).reprompt(speechOutput).getResponse();
   },
 };
 


### PR DESCRIPTION


*Description of changes:* `UnhandledIntent` was calling `speak` off of `attributesManager` when it should have been called off of `responseBuilder`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
