### PR TITLE
Fixed the template skill to be the trivia skill

### DIFF
--- a/instructions/2-lambda-function.md
+++ b/instructions/2-lambda-function.md
@@ -25,7 +25,7 @@ In the [first step of this guide](./1-voice-user-interface.md), we built the Voi
 
 5.  There are three boxes labeled "Author from scratch", "Blueprints" and "Serverless Application Repository". **Click the radio button in the box titled  "Serverless Application Repository"**  We have created a repository as a shortcut to getting everything set up for your skill.
 
-6. **Search for the application repository named "alexa-skills-kit-nodejs-factskill".** You can find it using the provided search box.  
+6. **Search for the application repository named "alexa-skills-kit-nodejs-triviaskill".** You can find it using the provided search box.  
 
 7. **Click on the repository.** This repository will create the Lambda function, add Alexa Skills Kit as it's trigger, and sets up an IAM role for you. It will also add the code from this GitHub repo and include it's dependencies to your Lambda function so that you don't have to upload it yourself.
 


### PR DESCRIPTION
The fact skill wasn't working, in the sense that the nodejs code to be pasted in the tutorial didn't work with it. There were missing dependencies, the "questions.js" source module was missing, etc.
I am sure you intended the trivia skill here, since this is a trivia skill tutorial, and otherwise it wouldn't work at all.

*Issue #, if available:*

*Description of changes:* fixed the reference to the "factskill" to point to the "triviaskill".


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
